### PR TITLE
PowerCMS の EntryWorkflow への対応

### DIFF
--- a/plugins/RebuildParentCategories/config.yaml
+++ b/plugins/RebuildParentCategories/config.yaml
@@ -11,4 +11,6 @@ callbacks:
     cms_post_delete.entry: $rebuildparentcategories::RebuildParentCategories::Plugin::_rebuild_parent_categories
     scheduled_post_published: $rebuildparentcategories::RebuildParentCategories::Plugin::_rebuild_parent_categories
     scheduled_post_unpublished: $rebuildparentcategories::RebuildParentCategories::Plugin::_rebuild_parent_categories
+    cms_workflow_published.entry: $rebuildparentcategories::RebuildParentCategories::Plugin::_rebuild_parent_categories
+    cms_workflow_published.page: $rebuildparentcategories::RebuildParentCategories::Plugin::_rebuild_parent_categories
 


### PR DESCRIPTION
- ワークフローのプレビュー画面から公開した場合に再構築されないケースへの対応
